### PR TITLE
[Travis] Add a CNAME file to all deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ install: cd frontend && npm ci && cd ..
 
 script: make ci
 
+# sets the CNAME file so github continues serving canvascbl.com
+before_deploy: echo "canvascbl.com" > bin/build/CNAME
+
 deploy:
   provider: pages
   skip_cleanup: true


### PR DESCRIPTION
This PR adds a `before_deploy` step to travis which writes `canvascbl.com` to `bin/build`.