### PR TITLE
[Frontend] Prefix env vars with REACT_APP_

### DIFF
--- a/frontend/src/util/getUrlPrefix.js
+++ b/frontend/src/util/getUrlPrefix.js
@@ -1,5 +1,5 @@
 export default process.env.NODE_ENV === 'development'
   ? 'http://localhost:8000'
-  : process.env.DEFAULT_API_URI
-  ? process.env.DEFAULT_API_URI
+  : process.env.REACT_APP_DEFAULT_API_URI
+  ? process.env.REACT_APP_DEFAULT_API_URI
   : '';


### PR DESCRIPTION
Currently only affects `DEFAULT_API_URI`