### PR TITLE
[Frontend] Add google analytics

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11269,6 +11269,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.1.tgz",
       "integrity": "sha512-V9yoTr6MeZXPPd4nV/05eCBvGH9cGzc52FN8fs0O0TVQ3HYYf1n7EgZVtHbldRq5xU9zEzoXIITjYNIfxDDdUw=="
     },
+    "react-ga": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.6.0.tgz",
+      "integrity": "sha512-GWHBWZDFjDGMkIk1LzroIn0mNTygKw3adXuqvGvheFZvlbpqMPbHsQsTdQBIxRRdXGQM/Zq+dQLRPKbwIHMTaw=="
+    },
     "react-is": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "react": "^16.9.0",
     "react-app-rewired": "^2.1.3",
     "react-dom": "^16.9.0",
+    "react-ga": "^2.6.0",
     "react-redux": "^7.1.1",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.1.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { HashRouter as Router, Route, Switch, Link } from 'react-router-dom';
 import { connect } from 'react-redux';
+import * as ReactGA from 'react-ga';
 
 import { gotStoredCredentials } from './actions/canvas';
 
@@ -28,6 +29,10 @@ function App(props) {
     // array change, and we want this code to run only once.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [true]);
+
+  ReactGA.initialize(process.env.REACT_APP_GOOGLE_ANALYTICS_ID);
+
+  ReactGA.pageview('/');
   return (
     <Router>
       <Switch>

--- a/frontend/src/components/Dashboard/index.js
+++ b/frontend/src/components/Dashboard/index.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { Switch, Route, Redirect, Link } from 'react-router-dom';
+import * as ReactGA from 'react-ga';
 
 import { Layout, Breadcrumb } from 'antd';
 
@@ -28,6 +29,7 @@ const getBreadcrumbNameMap = (courses = []) => {
 
 function Dashboard(props) {
   const { token } = props;
+  const [hasSentUserToGa, setHasSentUserToGa] = useState(false);
 
   // if no token exists, redirect
   if (!localStorage.token) {
@@ -37,7 +39,12 @@ function Dashboard(props) {
     return null;
   }
 
-  const { location } = props;
+  ReactGA.pageview(
+    props.location.pathname +
+      (props.location.search.includes('~') ? '' : props.location.search)
+  );
+
+  const { location, user } = props;
   const pathSnippets = location.pathname.split('/').filter(i => i);
   const breadcrumbNameMap = getBreadcrumbNameMap(props.courses || []);
   const breadcrumbItems = pathSnippets.map((_, index) => {
@@ -48,6 +55,11 @@ function Dashboard(props) {
       </Breadcrumb.Item>
     );
   });
+
+  if (hasSentUserToGa === false && user) {
+    ReactGA.set({ userId: user.id });
+    setHasSentUserToGa(true);
+  }
 
   return (
     <Layout className="layout">
@@ -92,7 +104,27 @@ function Dashboard(props) {
 
 const ConnectedDashboard = connect(state => ({
   token: state.canvas.token,
-  courses: state.canvas.courses
+  courses: state.canvas.courses,
+  user: state.canvas.user
 }))(Dashboard);
 
 export default ConnectedDashboard;
+
+/*
+
+avatar_url: "https://dtechhs.instructure.com/images/messages/avatar-50.png"
+bio: null
+calendar: {ics: "https://dtechhs.instructure.com/feeds/calendars/user_DCPxI1aLRwRaIkZ43PjlJqdoaoZIqW9oEyS9JaIa.ics"}
+effective_locale: "en"
+id: 396
+integration_id: null
+locale: null
+login_id: "smendelson21@dtechhs.org"
+lti_user_id: "2faffb2f42d8b058085a456b265d4df3a3dbeabd"
+name: "Sam Mendelson"
+primary_email: "smendelson21@dtechhs.org"
+short_name: "Sam Mendelson"
+sortable_name: "Mendelson, Sam"
+time_zone: "America/Los_Angeles"
+title: null
+ */


### PR DESCRIPTION
Now, during build, `process.env.REACT_APP_GOOGLE_ANALYTICS_ID` will fill in the google analytics ID for better frontend UI tracking.

Any query strings containing `~` are automatically exempted as those are canvas tokens.