### PR TITLE
[F/B] Properly logout, GREATLY improve speed

### DIFF
--- a/frontend/src/actions/canvas.js
+++ b/frontend/src/actions/canvas.js
@@ -167,6 +167,42 @@ export function getUserCourses(id, token, subdomain) {
   };
 }
 
+function gotOutcomeRollupsForCourse(results, courseId) {
+  return {
+    type: CANVAS_GOT_OUTCOME_ROLLUPS_FOR_COURSE,
+    results,
+    courseId
+  };
+}
+
+export function getOutcomeRollupsForCourse(
+  id,
+  userId,
+  courseId,
+  token,
+  subdomain
+) {
+  return async dispatch => {
+    dispatch(startLoading(id));
+    try {
+      const outcomeResults = await makeCanvasRequest(
+        `courses/${courseId}/outcome_rollups`,
+        token,
+        subdomain,
+        {
+          userId
+        }
+      );
+      dispatch(
+        gotOutcomeRollupsForCourse(outcomeResults.data.rollups, courseId)
+      );
+    } catch (e) {
+      dispatch(canvasProxyError(id, e.response));
+    }
+    dispatch(endLoading(id));
+  };
+}
+
 function gotOutcomeRollupsAndOutcomesForCourse(results, outcomes, courseId) {
   return {
     type: CANVAS_GOT_OUTCOME_ROLLUPS_AND_OUTCOMES_FOR_COURSE,

--- a/frontend/src/actions/canvas.js
+++ b/frontend/src/actions/canvas.js
@@ -30,12 +30,36 @@ export const CANVAS_GOT_OUTCOME_ROLLUPS_AND_OUTCOMES_FOR_COURSE =
 export const CANVAS_GOT_ASSIGNMENTS_FOR_COURSE =
   'CANVAS_GOT_ASSIGNMENTS_FOR_COURSE';
 
-export function logout() {
+function loggedOut(forwardUrl, error) {
   localStorage.token = '';
   localStorage.subdomain = '';
   localStorage.refreshToken = '';
+
+  if (forwardUrl.length > 1) {
+    window.location = forwardUrl;
+  }
+
   return {
-    type: CANVAS_LOGOUT
+    type: CANVAS_LOGOUT,
+    forwardUrl
+  };
+}
+
+export function logout(token, subdomain) {
+  return async dispatch => {
+    try {
+      const forwardUrl = await makeCanvasRequest(
+        'oauth2/token',
+        token,
+        subdomain,
+        {},
+        'delete'
+      ).then(res => res.data.forward_url);
+      dispatch(loggedOut(forwardUrl || ''));
+    } catch (e) {
+      // errors don't really matter
+      dispatch(loggedOut('', e));
+    }
   };
 }
 

--- a/frontend/src/components/Dashboard/Grades/GradeBreakdown/index.js
+++ b/frontend/src/components/Dashboard/Grades/GradeBreakdown/index.js
@@ -159,8 +159,14 @@ function GradeBreakdown(props) {
     error[getResultsId] ||
     error[getAssignmentsId];
 
+  const courseId = parseInt(props.match.params.courseId);
+
+  const allOutcomes = props.outcomes;
+
   useEffect(
     () => {
+      if (isNaN(courseId)) return;
+
       // loading before fetch because we don't want to request twice
       if (
         loading.includes(getCoursesId) ||
@@ -187,7 +193,10 @@ function GradeBreakdown(props) {
         return;
       }
 
-      if (!outcomeRollups && !getRollupsId) {
+      if (
+        (!outcomeRollups || !allOutcomes || !allOutcomes[courseId]) &&
+        !getRollupsId
+      ) {
         const id = v4();
         dispatch(
           getOutcomeRollupsAndOutcomesForCourse(
@@ -223,7 +232,6 @@ function GradeBreakdown(props) {
     [props]
   );
 
-  const courseId = parseInt(props.match.params.courseId);
   if (isNaN(courseId)) {
     notification.error({
       message: 'Invalid Course ID',

--- a/frontend/src/components/Dashboard/Grades/index.js
+++ b/frontend/src/components/Dashboard/Grades/index.js
@@ -8,7 +8,7 @@ import { Typography, Table, Icon, Spin } from 'antd';
 import {
   getUser,
   getUserCourses,
-  getOutcomeRollupsAndOutcomesForCourse
+  getOutcomeRollupsForCourse
 } from '../../../actions/canvas';
 
 import calculateGradeFromOutcomes from '../../../util/canvas/calculateGradeFromOutcomes';
@@ -89,6 +89,8 @@ function Grades(props) {
 
   const err = error[Object.keys(error).filter(eid => allIds.includes(eid))[0]];
 
+  const activeCourses = courses ? getActiveCourses(courses) : courses;
+
   useEffect(() => {
     if (allIds.some(id => loading.includes(id)) || err) {
       return;
@@ -111,21 +113,15 @@ function Grades(props) {
     }
 
     if (
-      (!outcomeRollups || courses.some(c => !outcomeRollups[c.id])) &&
+      (!outcomeRollups || activeCourses.some(c => !outcomeRollups[c.id])) &&
       !getOutcomeRollupsForCourseIds.length
     ) {
       const ids = [];
-      getActiveCourses(courses).forEach(c => {
+      activeCourses.forEach(c => {
         const id = v4();
         ids.push(id);
         dispatch(
-          getOutcomeRollupsAndOutcomesForCourse(
-            id,
-            user.id,
-            c.id,
-            token,
-            subdomain
-          )
+          getOutcomeRollupsForCourse(id, user.id, c.id, token, subdomain)
         );
       });
       setGetOutcomeRollupsForCourseIds(ids);
@@ -157,7 +153,6 @@ function Grades(props) {
   }
 
   const grades = calculateGradeFromOutcomes(outcomeRollups);
-  const activeCourses = getActiveCourses(courses);
 
   const data = activeCourses.map(c => ({
     key: c.id,
@@ -186,7 +181,6 @@ function Grades(props) {
 
 const ConnectedGrades = connect(state => ({
   courses: state.canvas.courses,
-  outcomes: state.canvas.outcomes,
   outcomeRollups: state.canvas.outcomeRollups,
   user: state.canvas.user,
   token: state.canvas.token,

--- a/frontend/src/components/Dashboard/Logout/index.js
+++ b/frontend/src/components/Dashboard/Logout/index.js
@@ -6,10 +6,15 @@ import { Redirect } from 'react-router-dom';
 import { logout } from '../../../actions/canvas';
 
 function Logout(props) {
-  props.dispatch(logout());
+  const { token, subdomain } = props;
+
+  props.dispatch(logout(token, subdomain));
   return <Redirect to="/" />;
 }
 
-const ConnectedLogout = connect(state => ({}))(Logout);
+const ConnectedLogout = connect(state => ({
+  token: state.canvas.token,
+  subdomain: state.canvas.subdomain
+}))(Logout);
 
 export default ConnectedLogout;

--- a/frontend/src/reducers/canvas.js
+++ b/frontend/src/reducers/canvas.js
@@ -60,12 +60,6 @@ export default function canvas(state = {}, action) {
       return {
         ...state,
         ...{
-          outcomes: {
-            ...state.outcomes,
-            ...{
-              [courseId]: action.outcomes
-            }
-          },
           outcomeRollups: {
             ...state.outcomeRollups,
             ...{

--- a/frontend/src/util/canvas/makeCanvasRequest.js
+++ b/frontend/src/util/canvas/makeCanvasRequest.js
@@ -1,9 +1,15 @@
 import axios from 'axios';
 import getUrlPrefix from '../getUrlPrefix';
 
-export default (path, token, subdomain = 'canvas', query = {}) =>
+export default (
+  path,
+  token,
+  subdomain = 'canvas',
+  query = {},
+  method = 'get'
+) =>
   axios({
-    method: 'get',
+    method,
     url: `${getUrlPrefix}/api/canvas/${path}`,
     headers: {
       'X-Canvas-Token': token,

--- a/src/canvasapis/oauth2.go
+++ b/src/canvasapis/oauth2.go
@@ -81,3 +81,21 @@ func OAuth2RefreshTokenHandler(w http.ResponseWriter, r *http.Request, _ httprou
 	util.HandleCanvasResponse(w, resp, body)
 	return
 }
+
+func DeleteOAuth2TokenHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ok, rd := util.GetRequestDetailsFromRequest(r)
+
+	if !ok {
+		util.SendUnauthorized(w, util.RequestDetailsFailedValidationMessage)
+		return
+	}
+
+	resp, body, err := services.DeleteOAuth2Token(rd)
+	if err != nil {
+		util.SendInternalServerError(w)
+		return
+	}
+
+	util.HandleCanvasResponse(w, resp, body)
+	return
+}

--- a/src/canvasapis/services/http.go
+++ b/src/canvasapis/services/http.go
@@ -53,3 +53,26 @@ func makePostRequest(url string) (*http.Response, string, error) {
 
 	return resp, string(body), nil
 }
+
+func makeDeleteRequest(url string) (* http.Response, string, error) {
+	client := http.Client{}
+
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return nil, "", err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return resp, string(body), nil
+}

--- a/src/canvasapis/services/oauth2.go
+++ b/src/canvasapis/services/oauth2.go
@@ -1,20 +1,15 @@
 package services
 
 import (
-	"fmt"
 	"github.com/iamtheyammer/canvas-grade-calculator/backend/src/env"
+	"github.com/iamtheyammer/canvas-grade-calculator/backend/src/util"
 	"net/http"
-	"net/url"
 )
 
 func GetOAuth2AccessTokenFromRedirectResponse(
 	code string,
 ) (*http.Response, string, error) {
-	oauth2URL := url.URL{
-		Host:   fmt.Sprintf("%s.instructure.com", env.OAuth2Subdomain),
-		Path:   "/login/oauth2/token",
-		Scheme: "https",
-	}
+	oauth2URL := util.GenerateCanvasURL("/login/oauth2/token", env.OAuth2Subdomain)
 
 	q := oauth2URL.Query()
 	q.Set("grant_type", "authorization_code")
@@ -29,11 +24,7 @@ func GetOAuth2AccessTokenFromRedirectResponse(
 func GetOAuth2AccessTokenFromRefreshToken(
 	rt string,
 ) (*http.Response, string, error) {
-	oauth2URL := url.URL{
-		Host:   fmt.Sprintf("%s.instructure.com", env.OAuth2Subdomain),
-		Path:   "/login/oauth2/token",
-		Scheme: "https",
-	}
+	oauth2URL := util.GenerateCanvasURL("/login/oauth2/token", env.OAuth2Subdomain)
 
 	q := oauth2URL.Query()
 	q.Set("grant_type", "refresh_token")
@@ -43,4 +34,16 @@ func GetOAuth2AccessTokenFromRefreshToken(
 	oauth2URL.RawQuery = q.Encode()
 
 	return makePostRequest(oauth2URL.String())
+}
+
+func DeleteOAuth2Token(
+	rd *util.RequestDetails,
+) (*http.Response, string, error) {
+	deleteTokenURL := util.GenerateCanvasURL("/login/oauth2/token", env.OAuth2Subdomain)
+
+	q := deleteTokenURL.Query()
+	q.Set("access_token", rd.Token)
+	deleteTokenURL.RawQuery = q.Encode()
+
+	return makeDeleteRequest(deleteTokenURL.String())
 }

--- a/src/main.go
+++ b/src/main.go
@@ -37,6 +37,7 @@ func getRouter() *httprouter.Router {
 	router.GET("/api/canvas/oauth2/request", canvasapis.OAuth2RequestHandler)
 	router.GET("/api/canvas/oauth2/response", canvasapis.OAuth2ResponseHandler)
 	router.GET("/api/canvas/oauth2/refresh_token", canvasapis.OAuth2RefreshTokenHandler)
+	router.DELETE("/api/canvas/oauth2/token", canvasapis.DeleteOAuth2TokenHandler)
 
 	return router
 }
@@ -62,6 +63,7 @@ func (_ MiddlewareRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// apply CORS headers
 	w.Header().Set("Access-Control-Allow-Origin", env.ProxyAllowedCORSOrigins)
+	w.Header().Set("Access-Control-Allow-Methods", "GET, DELETE")
 	w.Header().Set("Access-Control-Allow-Headers", "X-Canvas-Token, X-Canvas-Subdomain")
 	w.Header().Set("Access-Control-Expose-Headers", "X-Canvas-Url, X-Canvas-Status-Code")
 

--- a/src/util/generate.go
+++ b/src/util/generate.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"fmt"
+	"net/url"
+)
+
+func GenerateCanvasURL(path string, sd string) url.URL {
+	return url.URL{
+		Host: fmt.Sprintf("%s.instructure.com", sd),
+		Scheme: "https",
+		Path: path,
+	}
+}


### PR DESCRIPTION
## Properly logout

Added the `DELETE /api/canvas/oauth2/token` route to the proxy, and the frontend sends it when you click on logout.

## GREATLY improve speed

Updated the frontend to only pull outcomes when a breakdown is requested, rather than pulling them all when the grades table is requested.

In some tests, this improved loading time by a second.