### PR TITLE
[Frontend] Fix loader in GradeBreakdown causing rare crashes

### DIFF
--- a/frontend/src/components/Dashboard/Grades/GradeBreakdown/index.js
+++ b/frontend/src/components/Dashboard/Grades/GradeBreakdown/index.js
@@ -247,6 +247,8 @@ function GradeBreakdown(props) {
   if (
     !user ||
     !courses ||
+    !allOutcomes ||
+    !allOutcomes[courseId] ||
     !outcomeRollups ||
     !outcomeResults ||
     !outcomeResults[courseId] ||


### PR DESCRIPTION
Add outcomes to the if statement to show the loader in GradeBreakdown