### PR TITLE
[Frontend] Add version to frontend, add env util

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import ConnectedTokenEntry from './components/TokenEntry';
 import ConnectedOAuth2Response from './components/OAuth2Response';
 
 import Dashboard from './components/Dashboard';
+import env from './util/env';
 
 function App(props) {
   useEffect(() => {
@@ -30,7 +31,7 @@ function App(props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [true]);
 
-  ReactGA.initialize(process.env.REACT_APP_GOOGLE_ANALYTICS_ID);
+  ReactGA.initialize(env.googleAnalyticsId);
 
   ReactGA.pageview('/');
   return (

--- a/frontend/src/components/Dashboard/UpdateHandler/index.js
+++ b/frontend/src/components/Dashboard/UpdateHandler/index.js
@@ -2,10 +2,11 @@ import React, { useEffect } from 'react';
 import { Typography, List, Modal, Avatar } from 'antd';
 
 import changelog from '../../../assets/changelog';
+import env from '../../../util/env';
 
-function UpdateHandler(props) {
+function UpdateHandler() {
   useEffect(() => {
-    const currentVersion = parseInt(process.env.REACT_APP_CURRENT_VERSION);
+    const currentVersion = parseInt(env.currentVersion);
     // OAuth2Handler sets the current version to equal previous version so that new users
     // don't see a full changelog on first login. Users who were already logged in will see
     // a full changelog, though.

--- a/frontend/src/components/Dashboard/index.js
+++ b/frontend/src/components/Dashboard/index.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Switch, Route, Redirect, Link } from 'react-router-dom';
 import * as ReactGA from 'react-ga';
 
-import { Layout, Breadcrumb } from 'antd';
+import { Layout, Breadcrumb, Popover, Typography } from 'antd';
 
 import DashboardNav from './DashboardNav';
 import ConnectedUserProfile from './UserProfile';
@@ -11,6 +11,7 @@ import ConnectedGrades from './Grades';
 import ConnectedGradeBreakdown from './Grades/GradeBreakdown';
 import ConnectedLogout from './Logout';
 import UpdateHandler from './UpdateHandler';
+import env from '../../util/env';
 
 const { Content, Footer } = Layout;
 
@@ -99,7 +100,14 @@ function Dashboard(props) {
       </Content>
       <UpdateHandler />
       <Footer style={{ textAlign: 'center' }}>
-        Built by iamtheyammer 2019
+        <Popover
+          trigger="click"
+          content={
+            <Typography.Text>Version {env.currentVersion}</Typography.Text>
+          }
+        >
+          Built by iamtheyammer 2019
+        </Popover>
       </Footer>
     </Layout>
   );

--- a/frontend/src/components/OAuth2Response/index.js
+++ b/frontend/src/components/OAuth2Response/index.js
@@ -5,6 +5,7 @@ import { Redirect } from 'react-router-dom';
 import { notification } from 'antd';
 
 import { gotUserOAuth } from '../../actions/canvas';
+import env from '../../util/env';
 
 function OAuth2Response(props) {
   const query = parse(
@@ -37,7 +38,7 @@ function OAuth2Response(props) {
   );
 
   // set the version to current since it's a new user
-  localStorage.prevVersion = process.env.REACT_APP_CURRENT_VERSION;
+  localStorage.prevVersion = env.currentVersion;
 
   notification.success({
     message: 'Success!',

--- a/frontend/src/middleware/index.js
+++ b/frontend/src/middleware/index.js
@@ -2,10 +2,11 @@ import logger from 'redux-logger';
 import thunk from 'redux-thunk';
 
 import { applyMiddleware } from 'redux';
+import env from '../util/env';
 
 const middlewares = [thunk];
 
-if (process.env.NODE_ENV === 'development') {
+if (env.nodeEnv === 'development') {
   middlewares.push(logger);
 }
 

--- a/frontend/src/util/env.js
+++ b/frontend/src/util/env.js
@@ -1,0 +1,6 @@
+export default {
+  currentVersion: process.env.REACT_APP_CURRENT_VERSION,
+  defaultApiUri: process.env.REACT_APP_DEFAULT_API_URI,
+  googleAnalyticsId: process.env.REACT_APP_GOOGLE_ANALYTICS_ID,
+  nodeEnv: process.env.NODE_ENV
+};

--- a/frontend/src/util/getUrlPrefix.js
+++ b/frontend/src/util/getUrlPrefix.js
@@ -1,5 +1,7 @@
-export default process.env.NODE_ENV === 'development'
+import env from './env';
+
+export default env.nodeEnv === 'development'
   ? 'http://localhost:8000'
-  : process.env.REACT_APP_DEFAULT_API_URI
-  ? process.env.REACT_APP_DEFAULT_API_URI
+  : env.defaultApiUri
+  ? env.defaultApiUri
   : '';


### PR DESCRIPTION
- Add the version to the frontend-- click the footer
- Added an env util for getting env vars, this way names are centralized

This PR does **not** include an addition to the changelog because it doesn't have a user-facing change (well, except for the easter egg)